### PR TITLE
locals can be passed as `views` opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+var _ = require('lodash');
 var debug = require('debug')('co-views');
 var render = require('co-render');
 var path = require('path');
@@ -47,8 +48,11 @@ module.exports = function(dir, opts){
   var cache = opts.cache;
   if (null == cache) cache = 'development' != env;
 
+  // locals
+  opts.locals = opts.locals || {};
+
   return function(view, locals){
-    locals = locals || {};
+    locals = _.merge({}, opts.locals, locals || {});
 
     // default extname
     var e = extname(view);

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "koa"
   ],
   "dependencies": {
+    "co-render": "0.0.1",
     "debug": "*",
-    "co-render": "0.0.1"
+    "lodash": "^2.4.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
With this commit `locals` can be sent like this:

```js
var views = require('../../co-views');
module.exports = views(__dirname+'/../app/views', {
  map: { ... },
  locals: { ... } // this is needed for flexibility
});
```
This update also solves this proposal: https://github.com/visionmedia/co-views/pull/14
Please accept and merge. Thanks.
