### PR TITLE
Bugfix for Hogan partials introduced in 1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = function(dir, opts){
     // cache
     locals.cache = cache;
 
-    locals.partials = merge({}, partials);
+    locals.partials = merge(locals.partials || {}, partials || {});
 
     debug('render %s %j', view, locals);
     return render(view, locals);

--- a/test/fixtures/layout.html
+++ b/test/fixtures/layout.html
@@ -1,0 +1,1 @@
+<div>As far as I know, {{> user}}</div>

--- a/test/fixtures/user.html
+++ b/test/fixtures/user.html
@@ -1,0 +1,1 @@
+<p>{{user.name}} is a {{user.species}}</p>

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,7 @@ describe('views', function(){
     })
   })
 
-  it('should pass partials', function(){
+  it('pass partials in views.options', function(){
     return co(function *(){
       var tobi = {
         name: 'tobi',
@@ -45,15 +45,37 @@ describe('views', function(){
 
       var render = views(__dirname + '/fixtures', {
         map: {
-          hjs: 'hogan'
+          html: 'hogan'
         },
         partials: {
           user: 'user'
         }
       });
 
-      var html = yield render('layout.hjs', {
+      var html = yield render('layout', {
         user: tobi
+      });
+      assert.equal(html, '<div>As far as I know, <p>tobi is a ferret</p>\n</div>\n');
+    })
+  })
+  it('pass partials in render', function(){
+    return co(function *(){
+      var tobi = {
+        name: 'tobi',
+        species: 'ferret'
+      };
+
+      var render = views(__dirname + '/fixtures', {
+        map: {
+          html: 'hogan'
+        }
+      });
+
+      var html = yield render('layout', {
+        user: tobi,
+        partials: {
+          user: 'user'
+        }
       });
       assert.equal(html, '<div>As far as I know, <p>tobi is a ferret</p>\n</div>\n');
     })


### PR DESCRIPTION
The user should be able to specify `partials` per `render` call (I know it because I implemented that feature in `consolidate` https://github.com/tj/consolidate.js/pull/51). Prior 1.0.0 that was working without any change required to this module.

Related commit: https://github.com/tj/co-views/commit/9cdf9fd29d599bf10f5deda0a4806cb2bcf12a33
And PR: https://github.com/tj/co-views/pull/21

Now, I'm not sure what the author's idea was with defining global `partials` for the render, but with this fix the partials from `views.options` and those passed in `render.options` are merged. So that fixes existing clients using this combination of modules.

While on that, I don't see the point of using the `utils-merge` module, you can just `var extend = require('util')._extend` instead (for flat merge).

---

> Somehow it corrupts partials object, so on second and subsequent renders partials object filled not with filename, but with filename contents
https://github.com/tj/co-views/pull/21#issuecomment-107964781

That's implementation detail, check out the PR above.